### PR TITLE
商品詳細ページでの画像表示機能の実施

### DIFF
--- a/app/assets/javascripts/bxslider.js
+++ b/app/assets/javascripts/bxslider.js
@@ -6,4 +6,17 @@ $(function(){
       speed: 600
     });
   });
+  $(function(){
+    for (let i=1; i<=4; i++) {  //商品にカーソルを合わせると対象のイメージを表示する
+      let m = "#mini" + i
+      let b = "#big"  + i
+      $(m).mouseover(function() {
+        $('.mini').css("opacity", "0.5");
+        $(this).css('opacity', '1.0');
+        $(".bigs").not(b).css("display", "none");
+        $(b).fadeIn();
+      });
+    }
+  });
 });
+

--- a/app/assets/stylesheets/modules/_item-show.scss
+++ b/app/assets/stylesheets/modules/_item-show.scss
@@ -37,9 +37,17 @@ ul, li, h1, h2, h3, p {
         &-main {
           height: 300px;
           width: 300px;
-          .big {
-            height: 300px;
-            width: 300px;
+          .big-photo-box {
+            display: flex;
+            #big1 {
+              height: 300px;
+              width: 300px;
+            }
+            #big2,#big3,#big4 {
+              height: 300px;
+              width: 300px;
+              display:none
+            }
           }
         }
         &-sub {
@@ -49,9 +57,15 @@ ul, li, h1, h2, h3, p {
             height: 75px;
             width: 75px;
             float: left;
-            .mini {
+            #mini1 {
               height: 75px;
               width: 75px;
+              opacity:1.0;
+            }
+            #mini2, #mini3,#mini4 {
+              height: 75px;
+              width: 75px;
+              opacity:0.5;
             }
           }
         }

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -8,11 +8,15 @@
     .show-item__main--content
       .item-image
         .item-image-main
-          =image_tag "items/m22842714743_1.jpg", class: "big"
+          .big-photo-box
+            = image_tag "items/m22842714743_1.jpg", class: "bigs", id: "big1"
+            = image_tag "items/m22842714743_1.jpg", class: "bigs", id: "big2"
+            = image_tag "items/m22842714743_1.jpg", class: "bigs", id: "big3"
+            = image_tag "items/m22842714743_1.jpg", class: "bigs", id: "big4"
         .item-image-sub
-          - for num in 1..4
+          - @item.item_photos.each_with_index do |p, i|
             .image-sub
-              =image_tag "items/m22842714743_1.jpg", class: "mini"
+              =image_tag "items/m22842714743_1.jpg", class: "mini", id: "mini#{i + 1}"
 
       / 出品の詳細テーブル
       .item-detail-table


### PR DESCRIPTION
# what
・jsファイルではjqueryを使用し商品の小さい画像にマウスが乗ると上にある大きな画像が表示されるようにした。また、記述量を減らすためにfor文を使用し、各大きな画像と小さな画像のclassとidに個別の結びつけを行い実装した。
・scssファイルには同じ処理をしているclassやidに対して,同じcssプロパティで当てている。
・hamlファイルでは表品出品機能が実装できていないため、現状も仮置きの画像を置いており出品機能が実装できた際は実際の画像を表示するように変更したいと思います。

# why
画像に触れた際に該当の商品を画像を別で大きく表示をさせ、ユーザビリティの向上を図った。
