### PR TITLE
商品出品ページ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 config/secrets.yml
+public/uploads/*

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,6 +9,7 @@ class ItemsController < ApplicationController
 
   def new
     @item = Item.new
+    @item.item_photos.new
   end
 
   def create
@@ -41,7 +42,7 @@ class ItemsController < ApplicationController
   end
 
   def item_params
-    params.require(:item).permit(:name, :price,:description, :category_id,:buyer_id, :saler_id, :shipping_date_id,:condition_id,:region_id, :delivery_fee_id, :ship_method_id, :brand_id,:size_id, :transaction)
+    params.require(:item).permit(:name, :price, :description, :category_id, :buyer_id, :saler_id, :shipping_date_id, :condition_id, :region_id, :delivery_fee_id, :ship_method_id, :brand_id, :size_id, :transaction, item_photos_attributes: [:id, :photo])
   end
 
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -9,10 +9,11 @@ class Item < ApplicationRecord
   belongs_to :brand ,optional: true
 
   has_many :item_photos
+  accepts_nested_attributes_for :item_photos
   has_many :likes
 
-  belongs_to :saler, class_name: "User"
-  belongs_to :buyer, class_name: "User"
+  belongs_to :saler, class_name: "User" ,optional: true
+  belongs_to :buyer, class_name: "User" ,optional: true
 
   def self.get_items_category(id)
     return Item.where(category_id: id).order("id DESC").first(4)

--- a/app/models/item_photo.rb
+++ b/app/models/item_photo.rb
@@ -1,3 +1,4 @@
 class ItemPhoto < ApplicationRecord
   belongs_to :item
+  mount_uploader :photo, ImageUploader
 end

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -4,8 +4,13 @@ class ImageUploader < CarrierWave::Uploader::Base
   # include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
-  storage :fog
+  if Rails.env.development?
+    storage :file
+  elsif Rails.env.test?
+    storage :file
+  else
+    storage :fog
+  end
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -22,15 +22,16 @@
                       %p.sell-content__image-upload-box--content
                         最大4枚までアップロードできます
                       .sell-content__image-upload-box--sell-dropbox-container.clearfix.state-image-number-4
-                        = f.label :image, class: 'form-mask-image' do
-                          .sell-upload-drop-box
-                            %input.sell-upload-drop-box__sell-upload-drop-file{multiple: "multiple", name: "image1", style: "display: none;", type: "file"}/
-                            %pre.sell-upload-drop-box__visible-pc
-                              ドラッグアンドドロップ
-                              %br>/
-                              またはクリックしてファイルをアップロード
-                            %i.sell-upload-drop-box__icon-camera
-                          = f.file_field :image, class: 'hidden'
+                        = f.fields_for :item_photos, multiple: true do |fin|
+                          = fin.label :photo, class: 'form-mask-image' do
+                            .sell-upload-drop-box
+                              %input.sell-upload-drop-box__sell-upload-drop-file{multiple: true, name: "image1", style: "display: none;", type: "file"}/
+                              %pre.sell-upload-drop-box__visible-pc
+                                ドラッグアンドドロップ
+                                %br>/
+                                またはクリックしてファイルをアップロード
+                              %i.sell-upload-drop-box__icon-camera
+                          = fin.file_field :photo, class: 'hidden'
 
                   .sell-content
                     .sell-content__name


### PR DESCRIPTION
# what
・画像を投稿するためにitemとitem_photoモデルのアソシエーションをビューとコントローラーとモデルに記述する。
・画像投稿は出来たがエラーが出るためitem_photo.rbにマウントの記述をする。
・画像保存時にエラーがでたため、image_uploader.rbに入っているstorage :fileとstorage :fogをif文で記述をし開発、テスト、本番の環境により使用するファイルを変更するようにした。
・git hubに不要な画像データが入らないように.gitignoreに画像が保存されないように指定する。

※まだ画像投稿を複数枚での投稿ができるように実装が出来ていないため、別ブランチで対応します。

# why
・画像を投稿を可能にしたことにより、商品一覧画面、商品詳細画面等に置いて実際の商品画像を確認し、ユーザーが商品がどのようなものか、どのような状態かを確認して購入できるようにした。



