### PR TITLE
画像複数投稿プレビュー機能の実施

### DIFF
--- a/app/assets/javascripts/image_upload.js
+++ b/app/assets/javascripts/image_upload.js
@@ -1,0 +1,25 @@
+$(function() {
+  for (let i=1; i<=4; i++) {
+    $(`.photos${i}`).on('change', 'input[type="file"]', function(e) {
+        var file = e.target.files[0],
+          reader = new FileReader(),
+          $preview = $(`.photos${i}`);
+      if(file.type.indexOf("image") < 0){
+        return false;
+      }
+      reader.onload = (function(file) {
+        return function(e) {
+          $preview.append($('<img>').attr({
+                    src: e.target.result,
+                    width: "143px",
+                    height: "182px",
+          }));
+          $(`.box${i}`).css("display", "none");
+          $(`.photos${i + 1}`).show();
+          $(`img`).css("margin-left", "7px");
+        };
+      })(file);
+      reader.readAsDataURL(file);
+    });
+  };
+})

--- a/app/assets/stylesheets/modules/exhibit.scss
+++ b/app/assets/stylesheets/modules/exhibit.scss
@@ -70,10 +70,10 @@
                   display: block;
                   width: 620px;
                   margin: 16px auto 0;
+                  display: flex;
                   .form-mask-image{
                     .sell-upload-drop-box {
                       float: right;
-                      width: 620px - 80px;
                       margin: 0;
                       min-height: 120px;
                       padding: 40px;
@@ -110,26 +110,46 @@
                         pointer-events: none;
                         white-space: pre-wrap;
                         word-wrap: break-word;
+                        font-weight: 700;
                       }
                       &__icon-camera {
                         display: none;
                       }
                     }
                   }
-
-
-
-
-
-
-
-
-
-
-
-
                 }
               }
+.photos2,.photos3,.photos4 {
+  display: none;
+}
+.box1{
+   width: 540px;
+}
+.box2 {
+  width: 385px;
+  margin-left: 5px;
+}
+.box3 {
+  width: 230px;
+  margin-left: 5px;
+}
+.box4 {
+  width: 75px;
+  margin-left: 5px;
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
               &__name {
                 width: 620px;
                 &--input {
@@ -386,8 +406,10 @@
   }
 }
 
-.hidden{
-  display: none;
+.hiddens {
+  opacity: 0;
+  width: 100%;
+  height: 100px;
 }
 
 .modal{

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -10,7 +10,6 @@ class ItemsController < ApplicationController
   def new
     @item = Item.new
     @item.item_photos.build
-    # 4.times { @item.item_photos.build }
   end
 
   def create

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -21,17 +21,17 @@
                           %b 必須
                       %p.sell-content__image-upload-box--content
                         最大4枚までアップロードできます
-                      .sell-content__image-upload-box--sell-dropbox-container.clearfix.state-image-number-4
-                        = f.fields_for :item_photos do |fin|
-                          = fin.label :photo, class: 'form-mask-image' do
-                            .sell-upload-drop-box
-                              %pre.sell-upload-drop-box__visible-pc
-                                ドラッグアンドドロップ
-                                %br>/
-                                またはクリックしてファイルをアップロード
-                              %i.sell-upload-drop-box__icon-camera
-                          = fin.file_field :photo, class: 'hidden'
-
+                        .sell-content__image-upload-box--sell-dropbox-container.clearfix.state-image-number-4
+                          - 4.times do |i|
+                            = f.fields_for :item_photos do |fin|
+                              = fin.label :photo, class: 'form-mask-image' do
+                                .form-mask-image{class: "photos#{i + 1}"}
+                                  .sell-upload-drop-box{class: "box#{i + 1}"}
+                                    = fin.file_field :photo, class: 'hiddens'
+                                    %pre.sell-upload-drop-box__visible-pc
+                                      ドラッグアンドドロップ
+                                      %br>/
+                                      またはクリックしてファイルをアップロード
                   .sell-content
                     .sell-content__name
                       %label

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -38,7 +38,7 @@ ActiveRecord::Schema.define(version: 2019_02_11_103002) do
   end
 
   create_table "item_photos", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.text "photo"
+    t.text "photo", null: false
     t.bigint "item_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
# what
商品出品機能で実装されている画像の複数プレビュー機能の実施をしました。

・当初はitem-controllerからアソシエーション先のitem_photoモデルのデータを取得していましたが、個別のフィールドを消す、もしくは大きさに変化を与えることが難しかったため、新たに生成された各複数のフィールドに対してビューで繰り返しの処理し、個別のクラスを割り当てました。

・scssのファイルでは画面を開いた際にフィールドが見えないようにdisplay:flexとnoneのプロパティを使用。
各イベントをおこすための各クラスを作成。
不要であった閉じタグの削除を行った。

・jsファイルでは画像のプレビューをするイベントが走った際に、指定したクラスのフィールドに対して処理を消す、または新たに出現させるイベントで実装しました。なお、画像以外のものが処理されてもreturnで返すようにしました。

# why
ユーザビリティーの向上のため商品の出品を複数可能にし、かつプレビューしユーザーがどのアイテムを出品をしているか分かるようにした。

※※プレビューをしたアイテムに対する編集と削除の機能が実装できていませんが、他の必須タスクが残っているため、その実装が終わり次第に取り組みたいと考えています。

https://gyazo.com/b42792ffc055572b93d97ba3557d8106