### PR TITLE
取引状況の詳細画面の実装

### DIFF
--- a/app/views/users/complete.haml
+++ b/app/views/users/complete.haml
@@ -13,9 +13,9 @@
         - if @items.length == 0
           = image_tag "logo-gray-icon.svg", class: "logo"
           %h2売却済みの商品がありません
+        - else
       %ul.show
-        - if @items.length >= 1
-          = render partial: "complete"
+        = render partial: "complete"
     .user-item__box--button
       = link_to "", class: "button-left" do
         = fa_icon "angle-left"

--- a/app/views/users/complete.haml
+++ b/app/views/users/complete.haml
@@ -10,13 +10,12 @@
           = link_to "取引中", progress_users_path, class: "differ"
         %li.select__tag
           = link_to "売却済み", "", class: "active"
-      / 商品の有無での条件分岐
-      / = image_tag "logo-gray-icon.svg", class: "logo"
-      / %h2 売却済みの商品がありません
+        - if @items.length == 0
+          = image_tag "logo-gray-icon.svg", class: "logo"
+          %h2売却済みの商品がありません
       %ul.show
-        / 売却済の商品を取り出し
-        = render partial: "complete"
-
+        - if @items.length >= 1
+          = render partial: "complete"
     .user-item__box--button
       = link_to "", class: "button-left" do
         = fa_icon "angle-left"

--- a/app/views/users/progress.haml
+++ b/app/views/users/progress.haml
@@ -10,12 +10,12 @@
           = link_to "取引中", "", class: "active"
         %li.select__tag
           = link_to "売却済み", complete_users_path, class: "differ"
-      / 商品の有無での条件分岐
-      / = image_tag "logo-gray-icon.svg", class: "logo"
-      / %h2 取引中の商品がありません
+      - if @items.length == 0
+        = image_tag "logo-gray-icon.svg", class: "logo"
+        %h2売却済みの商品がありません
       %ul.show
-        / 取引中の商品を取り出し
-        = render partial: "progress"
+        - if @items.length >= 1
+          = render partial: "progress"
 
     .user-item__box--button
       = link_to "", class: "button-left" do

--- a/app/views/users/progress.haml
+++ b/app/views/users/progress.haml
@@ -12,11 +12,10 @@
           = link_to "売却済み", complete_users_path, class: "differ"
       - if @items.length == 0
         = image_tag "logo-gray-icon.svg", class: "logo"
-        %h2売却済みの商品がありません
+        %h2取引中の商品がありません。
+      - else
       %ul.show
-        - if @items.length >= 1
-          = render partial: "progress"
-
+        = render partial: "progress"
     .user-item__box--button
       = link_to "", class: "button-left" do
         = fa_icon "angle-left"

--- a/app/views/users/purchase.haml
+++ b/app/views/users/purchase.haml
@@ -8,11 +8,11 @@
           = link_to "取引中", "", class: "active"
         %li.select__tag
           = link_to "過去の取引", purchased_users_path, class: "differ"
-      / 商品の有無での条件分岐
-      / = image_tag "logo-gray-icon.svg", class: "logo"
-      / %h2 取引中の商品がありません
+      - if @items.length == 0
+        = image_tag "logo-gray-icon.svg", class: "logo"
+        %h2取引中の商品がありません
       %ul.show
-        / 取引中の商品を取り出し
-        = render partial: "purchase"
+        - if @items.length >= 1
+          = render partial: "purchase"
 
     = render partial: 'user_side_bar'

--- a/app/views/users/purchase.haml
+++ b/app/views/users/purchase.haml
@@ -11,8 +11,7 @@
       - if @items.length == 0
         = image_tag "logo-gray-icon.svg", class: "logo"
         %h2取引中の商品がありません
+      - else
       %ul.show
-        - if @items.length >= 1
-          = render partial: "purchase"
-
+        = render partial: "purchase"
     = render partial: 'user_side_bar'

--- a/app/views/users/purchased.haml
+++ b/app/views/users/purchased.haml
@@ -8,11 +8,11 @@
           = link_to "取引中", purchase_users_path, class: "differ"
         %li.select__tag
           = link_to "過去の取引", "", class: "active"
-      / 商品の有無での条件分岐
-      / = image_tag "logo-gray-icon.svg", class: "logo"
-      / %h2 購入した商品がありません
+        - if @items.length == 0
+          = image_tag "logo-gray-icon.svg", class: "logo"
+          %h2購入した商品がありません
       %ul.show
-        / 購入済みの商品を取り出し
-        = render partial: "purchased"
+        - if @items.length >= 1
+          = render partial: "purchased"
 
     = render partial: 'user_side_bar'

--- a/app/views/users/purchased.haml
+++ b/app/views/users/purchased.haml
@@ -11,8 +11,7 @@
         - if @items.length == 0
           = image_tag "logo-gray-icon.svg", class: "logo"
           %h2購入した商品がありません
+        - else
       %ul.show
-        - if @items.length >= 1
-          = render partial: "purchased"
-
+        = render partial: "purchased"
     = render partial: 'user_side_bar'

--- a/app/views/users/selling.haml
+++ b/app/views/users/selling.haml
@@ -13,9 +13,9 @@
       - if @items.length == 0
         = image_tag "logo-gray-icon.svg", class: "logo"
         %h2出品中の商品がありません
+      - else
       %ul.show
-        - if @items.length >= 1
-          = render partial: "selling"
+        = render partial: "selling"
     .user-item__box--button
       = link_to "", class: "button-left" do
         = fa_icon "angle-left"

--- a/app/views/users/selling.haml
+++ b/app/views/users/selling.haml
@@ -10,13 +10,12 @@
           = link_to "取引中", progress_users_path, class: "differ"
         %li.select__tag
           = link_to "売却済み", complete_users_path, class: "differ"
-      / 商品の有無での条件分岐
-      / = image_tag "logo-gray-icon.svg", class: "logo"
-      / %h2 出品中の商品がありません
+      - if @items.length == 0
+        = image_tag "logo-gray-icon.svg", class: "logo"
+        %h2出品中の商品がありません
       %ul.show
-        / 出品中の商品を取り出し
-        = render partial: "selling"
-
+        - if @items.length >= 1
+          = render partial: "selling"
     .user-item__box--button
       = link_to "", class: "button-left" do
         = fa_icon "angle-left"


### PR DESCRIPTION
# what
取引状況に一致するカラムとしてtradingカラムを使用し、一致するアイテムの数が一つ以上あらばアイテムの一覧を表示させ、なければメルカリのロゴとコメントを表示するように実装しました。
https://gyazo.com/547139e60527627047b491f27b6c8565
# why
ユーザーがアイテムの取引状況を確認できるようにし、今後の購入者、出品者との取引を円滑に進めることができるようにしました。

##
コントローラーでの記述が抜けていましたので下記の画像でご確認のほどよろしくお願いします。https://gyazo.com/7ad983b76013a826f331161cbfe90bb7